### PR TITLE
Добавление пользователя в группу в зависимости от его роли.

### DIFF
--- a/adaptive_hockey_federation/core/constants.py
+++ b/adaptive_hockey_federation/core/constants.py
@@ -12,6 +12,16 @@ ROLES_CHOICES = (
     (ROLE_ADMIN, "Администратор"),
 )
 
+GROUP_ADMINS = "Администраторы"
+GROUP_MODERATORS = "Модераторы"
+GROUP_AGENTS = "Агенты"
+
+GROUPS_BY_ROLE = {
+    ROLE_ADMIN: GROUP_ADMINS,
+    ROLE_AGENT: GROUP_AGENTS,
+    ROLE_MODERATOR: GROUP_MODERATORS,
+}
+
 # constants for main/models.py
 CHAR_FIELD_LENGTH = 256
 EMPTY_VALUE_DISPLAY = ""

--- a/adaptive_hockey_federation/tests/fixture_user.py
+++ b/adaptive_hockey_federation/tests/fixture_user.py
@@ -1,10 +1,11 @@
 import pytest
 
-test_password = 'admin'
-test_name = 'admin'
-test_lastname = 'admin'
-test_role = 'admin'
-test_email = 'admin@admin.ru'
+test_password = "admin"
+test_name = "admin"
+test_lastname = "admin"
+test_role_admin = "admin"
+test_role_user = "user"
+test_email = "admin@admin.ru"
 
 
 @pytest.fixture
@@ -13,7 +14,7 @@ def user(django_user_model):
         password=test_password,
         first_name=test_name,
         last_name=test_lastname,
-        role=test_role,
+        role=test_role_admin,
         email=test_email,
     )
 
@@ -27,9 +28,7 @@ def user_client(user, client):
 @pytest.fixture
 def adminuser(djangousermodel):
     admin = djangousermodel.objects.createsuperuser(
-        first_name='admin',
-        email='admin@admin.com',
-        password='admin'
+        first_name="admin", email="admin@admin.com", password="admin"
     )
     admin.isstaff = True
     admin.issuperuser = True
@@ -40,8 +39,8 @@ def adminuser(djangousermodel):
 @pytest.fixture
 def moderatoruser(djangousermodel):
     moderator = djangousermodel.objects.createuser(
-        first_name='moderator',
-        email='moderator@moderator.com',
-        password='moderator'
+        first_name="moderator",
+        email="moderator@moderator.com",
+        password="moderator",
     )
     return moderator

--- a/adaptive_hockey_federation/tests/utils.py
+++ b/adaptive_hockey_federation/tests/utils.py
@@ -159,7 +159,9 @@ class UrlToTest:
         НЕ обладающего разрешением с codename, сохраненным в self.permission.
         Последним значением возвращает сообщение, которое можно использовать
         в тестах."""
-        response = self._get_auth_response(client, user)
+        response = self._get_auth_response(
+            client, user, clear_permissions=True
+        )
         if isinstance(self.permission, Permission):
             codename = self.permission.codename
         else:

--- a/adaptive_hockey_federation/users/constants.py
+++ b/adaptive_hockey_federation/users/constants.py
@@ -1,3 +1,15 @@
-GROUP_NAMES = ["Администраторы", "Модераторы", "Агенты",]
-MODERATORS_PERMS = ["change_user", "change_team", "change_player",]
-AGENTS_PERMS = ["change_player",]
+from core.constants import GROUP_ADMINS, GROUP_AGENTS, GROUP_MODERATORS
+
+GROUP_NAMES = [
+    GROUP_ADMINS,
+    GROUP_MODERATORS,
+    GROUP_AGENTS,
+]
+MODERATORS_PERMS = [
+    "change_user",
+    "change_team",
+    "change_player",
+]
+AGENTS_PERMS = [
+    "change_player",
+]

--- a/adaptive_hockey_federation/users/models.py
+++ b/adaptive_hockey_federation/users/models.py
@@ -1,5 +1,8 @@
+from typing import Iterable
+
 from core.constants import (
     EMAIL_MAX_LENGTH,
+    GROUPS_BY_ROLE,
     NAME_MAX_LENGTH,
     QUERY_SET_LENGTH,
     ROLE_ADMIN,
@@ -12,9 +15,11 @@ from django.contrib.auth.models import (
     Group,
     PermissionsMixin,
 )
+from django.core.exceptions import ValidationError
 from django.core.mail import send_mail
 from django.core.validators import EmailValidator
 from django.db import models
+from django.http import Http404
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 from phonenumber_field.modelfields import PhoneNumberField
@@ -30,26 +35,26 @@ class User(AbstractBaseUser, PermissionsMixin):
 
     first_name = models.CharField(
         max_length=NAME_MAX_LENGTH,
-        verbose_name=_('Имя'),
-        help_text=_('Имя'),
+        verbose_name=_("Имя"),
+        help_text=_("Имя"),
     )
     last_name = models.CharField(
         max_length=NAME_MAX_LENGTH,
-        verbose_name=_('Фамилия'),
-        help_text=_('Фамилия'),
+        verbose_name=_("Фамилия"),
+        help_text=_("Фамилия"),
     )
     patronymic = models.CharField(
         blank=True,
         max_length=NAME_MAX_LENGTH,
-        verbose_name=_('Отчество'),
-        help_text=_('Отчество'),
+        verbose_name=_("Отчество"),
+        help_text=_("Отчество"),
     )
     role = models.CharField(
         choices=ROLES_CHOICES,
         default=ROLE_AGENT,
         max_length=max(len(role) for role, _ in ROLES_CHOICES),
-        verbose_name=_('Роль'),
-        help_text=_('Уровень прав доступа'),
+        verbose_name=_("Роль"),
+        help_text=_("Уровень прав доступа"),
     )
     email = models.EmailField(
         max_length=EMAIL_MAX_LENGTH,
@@ -57,43 +62,43 @@ class User(AbstractBaseUser, PermissionsMixin):
         validators=(
             EmailValidator(
                 message="Используйте корректный адрес электронной почты. "
-                        "Адрес должен быть не длиннее 150 символов. "
-                        "Допускается использование латинских букв, "
-                        "цифр и символов @/./+/-/_"
+                "Адрес должен быть не длиннее 150 символов. "
+                "Допускается использование латинских букв, "
+                "цифр и символов @/./+/-/_"
             ),
         ),
-        verbose_name=_('Электронная почта'),
-        help_text=_('Электронная почта'),
+        verbose_name=_("Электронная почта"),
+        help_text=_("Электронная почта"),
     )
     phone = PhoneNumberField(
         blank=True,
         validators=[validate_international_phonenumber],
-        verbose_name=_('Актуальный номер телефона'),
-        help_text=_('Номер телефона, допустимый формат - +7 ХХХ ХХХ ХХ ХХ'),
+        verbose_name=_("Актуальный номер телефона"),
+        help_text=_("Номер телефона, допустимый формат - +7 ХХХ ХХХ ХХ ХХ"),
     )
     date_joined = models.DateTimeField(
         default=timezone.now,
-        verbose_name=_('Дата регистрации.'),
+        verbose_name=_("Дата регистрации."),
     )
     is_staff = models.BooleanField(
         default=False,
-        verbose_name=_('Статус администратора.'),
+        verbose_name=_("Статус администратора."),
     )
     is_active = models.BooleanField(
         default=True,
-        verbose_name=_('Показывает статус он-лайн.'),
+        verbose_name=_("Показывает статус он-лайн."),
     )
 
     objects = CustomUserManager()
 
     EMAIL_FIELD = "email"
-    USERNAME_FIELD = 'email'
-    REQUIRED_FIELDS = ['first_name', 'last_name', 'role']
+    USERNAME_FIELD = "email"
+    REQUIRED_FIELDS = ["first_name", "last_name", "role"]
 
     class Meta:
-        verbose_name = _('Пользователь')
-        verbose_name_plural = _('Пользователи')
-        ordering = ('last_name',)
+        verbose_name = _("Пользователь")
+        verbose_name_plural = _("Пользователи")
+        ordering = ("last_name",)
 
     def clean(self):
         super().clean()
@@ -104,13 +109,26 @@ class User(AbstractBaseUser, PermissionsMixin):
 
     def get_full_name(self):
         return (
-            f'{self.last_name[:QUERY_SET_LENGTH]} '
-            f'{self.first_name[:QUERY_SET_LENGTH]} '
-            f'{self.patronymic[:QUERY_SET_LENGTH]}'
+            f"{self.last_name[:QUERY_SET_LENGTH]} "
+            f"{self.first_name[:QUERY_SET_LENGTH]} "
+            f"{self.patronymic[:QUERY_SET_LENGTH]}"
         )
 
     def email_user(self, subject, message, from_email=None, **kwargs):
         send_mail(subject, message, from_email, [self.email], **kwargs)
+
+    def save(
+        self,
+        force_insert: bool = False,
+        force_update: bool = False,
+        using: str | None = None,
+        update_fields: Iterable[str] | None = None,
+    ) -> None:
+        """Переопределенный метод модели.
+        При любом сохранении устанавливает группу пользователя в зависимости
+        от его роли."""
+        super().save()
+        self.set_group()
 
     @property
     def is_agent(self):
@@ -137,6 +155,18 @@ class User(AbstractBaseUser, PermissionsMixin):
         """
         return self.role == ROLE_ADMIN or self.is_staff
 
+    def set_group(self):
+        """Добавляет пользователя в группу в зависимости от его роли."""
+        if not (group_name := GROUPS_BY_ROLE.get(self.role, None)):
+            raise ValidationError(
+                f"Неизвестная роль пользователя: " f"{self.role}"
+            )
+        if group := ProxyGroup.get_by_name(group_name):
+            self.groups.clear()
+            self.groups.add(group)
+        else:
+            raise Http404(f"Не найдена группа {group_name}")
+
 
 class ProxyGroup(Group):
     """Обычная группа django. Класс необходим для регистрации
@@ -149,3 +179,13 @@ class ProxyGroup(Group):
 
     def __str__(self):
         return self.name
+
+    @classmethod
+    def get_by_name(cls, name: str) -> Group | None:
+        """Возвращает группу по полю "name".
+        Предварительно проверяет наличие таковой группы.
+        ВНИМАНИЕ!!! Метод не вызывает исключения при отсутствии в БД искомой
+        группы, а вместо исключения возвращает None."""
+        if (obj := cls.objects.filter(name=name)).exists():
+            return obj.first()
+        return None


### PR DESCRIPTION
Реализован функционал добавления пользователя в группу в зависимости от его роли. 

# Description

Функционал работает в автоматическом режиме. Это распространяется и на фабрики. Теперь при заполнении базы через `make fill-test-db`  мы получаем полное распределение пользователей по группам. 

## Type of change

Пожалуйста, удалите варианты, которые не относятся к ПР-у.

- [ ] Bug fix (non-breaking change which fixes an issue)
Пришлось немного подправить тесты. 
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
!!! В соответствии с концепцией приложения по состоянию на сегодня, добавление пользователя в более, чем одну группу более невозможно: группа все равно сбросится на ту, которая соответствует роли пользователя. !!!

# How Has This Been Tested?

Опишите, пожалуйста, тесты, которые вы провели для проверки ваших изменений. Предоставьте инструкции, чтобы мы могли воспроизвести их. Также укажите все необходимые детали конфигурации тестов.

## Checklist:

- [ ] Мой код соответствует code-style данного проекта
- [ ] Я провел самоанализ собственного кода
- [ ] Я внес соответствующие изменения в документацию
