### PR TITLE
bugfix: password for factories_user

### DIFF
--- a/adaptive_hockey_federation/users/factories.py
+++ b/adaptive_hockey_federation/users/factories.py
@@ -1,5 +1,6 @@
 import factory  # type: ignore
 from django.contrib.auth import get_user_model
+from django.contrib.auth.hashers import make_password
 
 User = get_user_model()
 
@@ -16,7 +17,10 @@ class UserFactory(factory.django.DjangoModelFactory):
     patronymic = factory.Faker("first_name", locale="ru_RU")
     email = factory.Faker("email", locale="ru_RU")
     phone = factory.Faker("phone_number", locale="ru_RU")
-    password = factory.PostGenerationMethodCall("set_password", "pass1234")
+
+    @factory.lazy_attribute
+    def password(self):
+        return make_password("pass1234")
 
     @factory.post_generation
     def admin_create(self, create, extracted, **kwargs):


### PR DESCRIPTION
# Description
Исправлен баг, связанный с паролем юзеров созданных через фабрику. Пароль "pass1234" создаётся и хешируется корректно, вход под тестовым юзером так-же происходит корректно.

![Снимок экрана от 2024-03-09 11-27-04](https://github.com/Studio-Yandex-Practicum/adaptive_hockey_federation/assets/106034945/77766a68-d966-4016-9880-b3d41bb89b90)


## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Тестирование провёл мануальным способом, заново создал пользователей, и залогинился.

## Checklist:

- [X] Мой код соответствует code-style данного проекта
- [X] Я провел самоанализ собственного кода
- [ ] Я внес соответствующие изменения в документацию
