### PR TITLE
 Неудачная попытка валидации кода тел. страны # 205

### DIFF
--- a/adaptive_hockey_federation/users/constants.py
+++ b/adaptive_hockey_federation/users/constants.py
@@ -42,3 +42,4 @@ GROUP_PERMISSION = {
         ),
     ),
 }
+REGEX_AREA_CODE_IS_SEVEN_HUNDRED = "^7[0-9]{2,10}$"

--- a/adaptive_hockey_federation/users/factories.py
+++ b/adaptive_hockey_federation/users/factories.py
@@ -1,5 +1,6 @@
 import factory  # type: ignore
 from django.contrib.auth import get_user_model
+from phonenumber_field.phonenumber import PhoneNumber, to_python
 
 User = get_user_model()
 
@@ -25,3 +26,15 @@ class UserFactory(factory.django.DjangoModelFactory):
                 self.is_staff = True
                 if self.role == "admin":
                     self.is_superuser = True
+
+    @factory.post_generation
+    def phone_create(self, create, extracted, **kwargs):
+        if create:
+            phone_number = to_python(self.phone)
+            for _ in range(30):
+                if (
+                    isinstance(phone_number, PhoneNumber) 
+                    and not phone_number.is_valid()
+                ):
+                    return factory.Faker("phone_number", locale="ru_RU")
+                return self.phone

--- a/adaptive_hockey_federation/users/factories.py
+++ b/adaptive_hockey_federation/users/factories.py
@@ -1,5 +1,6 @@
 import factory  # type: ignore
 from django.contrib.auth import get_user_model
+from django.contrib.auth.hashers import make_password
 from faker import Faker
 from users.provaders import CustomPhoneProvider
 
@@ -20,7 +21,10 @@ class UserFactory(factory.django.DjangoModelFactory):
     patronymic = factory.Faker("first_name", locale="ru_RU")
     email = factory.Faker("email", locale="ru_RU")
     phone = factory.LazyAttribute(lambda _: fake.phone_number())
-    password = factory.PostGenerationMethodCall("set_password", "pass1234")
+
+    @factory.lazy_attribute
+    def password(self):
+        return make_password("pass1234")
 
     @factory.post_generation
     def admin_create(self, create, extracted, **kwargs):

--- a/adaptive_hockey_federation/users/forms.py
+++ b/adaptive_hockey_federation/users/forms.py
@@ -152,6 +152,8 @@ class UsersCreationForm(forms.ModelForm):
         self.fields["patronymic"].required = False
         self.fields["role"].required = True
         self.fields["phone"].required = True
+        self.fields["email"].required = False #(удалю её) Временная строка, т.к. 
+        # выходит ошибка при создании пользователя админом, 
 
     def clean_team(self):
         """

--- a/adaptive_hockey_federation/users/forms.py
+++ b/adaptive_hockey_federation/users/forms.py
@@ -152,8 +152,6 @@ class UsersCreationForm(forms.ModelForm):
         self.fields["patronymic"].required = False
         self.fields["role"].required = True
         self.fields["phone"].required = True
-        self.fields["email"].required = False #(удалю её) Временная строка, т.к. 
-        # выходит ошибка при создании пользователя админом, 
 
     def clean_team(self):
         """

--- a/adaptive_hockey_federation/users/models.py
+++ b/adaptive_hockey_federation/users/models.py
@@ -25,6 +25,7 @@ from django.utils.translation import gettext_lazy as _
 from phonenumber_field.modelfields import PhoneNumberField
 from phonenumber_field.validators import validate_international_phonenumber
 from users.managers import CustomUserManager
+from users.validators import zone_code_without_seven_hundred
 
 
 class User(AbstractBaseUser, PermissionsMixin):
@@ -72,7 +73,10 @@ class User(AbstractBaseUser, PermissionsMixin):
     )
     phone = PhoneNumberField(
         blank=True,
-        validators=[validate_international_phonenumber],
+        validators=[
+            validate_international_phonenumber,
+            zone_code_without_seven_hundred
+        ],
         verbose_name=_("Актуальный номер телефона"),
         help_text=_("Номер телефона, допустимый формат - +7 ХХХ ХХХ ХХ ХХ"),
     )

--- a/adaptive_hockey_federation/users/provaders.py
+++ b/adaptive_hockey_federation/users/provaders.py
@@ -1,0 +1,18 @@
+import phonenumbers
+from core.config.base_settings import PHONENUMBER_DEFAULT_REGION
+from faker.providers.phone_number.ru_RU import Provider
+
+
+class CustomPhoneProvider(Provider):
+    def phone_number(self):
+        while True:
+            phone_number = self.numerify(self.random_element(self.formats))
+            parsed_number = phonenumbers.parse(
+                phone_number,
+                PHONENUMBER_DEFAULT_REGION
+            )
+            if phonenumbers.is_valid_number(parsed_number):
+                return phonenumbers.format_number(
+                    parsed_number,
+                    phonenumbers.PhoneNumberFormat.INTERNATIONAL
+                )

--- a/adaptive_hockey_federation/users/provaders.py
+++ b/adaptive_hockey_federation/users/provaders.py
@@ -1,6 +1,9 @@
+import re
+
 import phonenumbers
 from core.config.base_settings import PHONENUMBER_DEFAULT_REGION
 from faker.providers.phone_number.ru_RU import Provider
+from users.constants import REGEX_AREA_CODE_IS_SEVEN_HUNDRED
 
 
 class CustomPhoneProvider(Provider):
@@ -11,8 +14,12 @@ class CustomPhoneProvider(Provider):
                 phone_number,
                 PHONENUMBER_DEFAULT_REGION
             )
-            if phonenumbers.is_valid_number(parsed_number):
-                return phonenumbers.format_number(
-                    parsed_number,
-                    phonenumbers.PhoneNumberFormat.INTERNATIONAL
-                )
+            if not re.search(
+                REGEX_AREA_CODE_IS_SEVEN_HUNDRED,
+                str(parsed_number.national_number)
+            ):
+                if phonenumbers.is_valid_number(parsed_number):
+                    return phonenumbers.format_number(
+                        parsed_number,
+                        phonenumbers.PhoneNumberFormat.INTERNATIONAL
+                    )

--- a/adaptive_hockey_federation/users/validators.py
+++ b/adaptive_hockey_federation/users/validators.py
@@ -1,0 +1,12 @@
+from django.core.exceptions import ValidationError
+
+
+def zone_code_without_seven_hundred(phone):
+    if (
+        phone[0:2] == "87" or phone[0:3] == "8 7" or phone[0:4] == "8 (7"
+        or phone[0:3] == "+77" or phone[0:4] == "+7 7" or phone[0:5] == "+7 (7"
+    ):
+        raise ValidationError(
+            "Выберете код в 8 (***) в из следующих вариантов:"
+            "3**, 4**, 8**, 9**."
+        )


### PR DESCRIPTION
# Description
Опираясь на предположения и предложения Дениса Панасенко, проверила:
- фабрика генерирует некорректные коды телефонов и загружает их в бд;
- при создании пользователя самостоятельно, валидация работает успешно;
- валидацию решина настраивать на уровне фабрики, используя переделанный код метода validate_international_phonenumber из библиотеки PhoneNumberField;
- создавая пользователя выходит ошибка, пользователь при этом в базе сохраняется. 
![2024-03-08_21-18-27](https://github.com/Studio-Yandex-Practicum/adaptive_hockey_federation/assets/122533248/3ca20792-0e07-499a-8bf3-ed8a497af6a3)
Ошибка касается поля *email*, поэтому на момент выполнения таски поле ввода почты сделала необязательным.
При редактировании пользователя и внесении почты, пользователь сохраняется без ошибки.
- валидацию решина настраивать на уровне фабрики, используя переделанный код метода validate_international_phonenumber из библиотеки PhoneNumberField.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] Мой код соответствует code-style данного проекта
- [x] Я провела слезный самоанализ собственного кода, покритикуй, пожалуйста


