### PR TITLE
Feature/rename folder for volume and make path for media files through virtual server

### DIFF
--- a/adaptive_hockey_federation/main/models.py
+++ b/adaptive_hockey_federation/main/models.py
@@ -457,7 +457,7 @@ class Document(BaseUniqueName):
         help_text=_("Наименование"),
     )
     file = models.FileField(
-        upload_to="documents",
+        upload_to="players_documents",
         max_length=CHAR_FIELD_LENGTH,
         unique=True,
     )

--- a/adaptive_hockey_federation/unloads/factories.py
+++ b/adaptive_hockey_federation/unloads/factories.py
@@ -34,7 +34,7 @@ class UnloadFactory(factory.django.DjangoModelFactory):
             queryset = queryset_with_titles[0]
             filename = f"{title}_{obj.unload_name}.xlsx"
             export_excel(queryset, filename, title)
-            file_path = os.path.join("data", filename)
+            file_path = os.path.join("unloads_data", filename)
             obj.unload_file_slug = file_path
             obj.save()
 

--- a/adaptive_hockey_federation/unloads/models.py
+++ b/adaptive_hockey_federation/unloads/models.py
@@ -22,7 +22,7 @@ class Unload(models.Model):
         on_delete=models.CASCADE,
     )
     unload_file_slug = models.FileField(
-        verbose_name=_("Ссылка на файл"), upload_to="data/"
+        verbose_name=_("Ссылка на файл"), upload_to="unloads_data/"
     )
 
     class Meta:

--- a/adaptive_hockey_federation/unloads/utils.py
+++ b/adaptive_hockey_federation/unloads/utils.py
@@ -32,7 +32,7 @@ def export_excel(queryset: QuerySet, filename: str, title: str) -> None:
     base_filename, file_extension = os.path.splitext(filename)
     filename_with_timestamp = f"{base_filename}_{timestamp}{file_extension}"
 
-    media_data_path = os.path.join(settings.MEDIA_ROOT, "data")
+    media_data_path = os.path.join(settings.MEDIA_ROOT, "unloads_data")
     os.makedirs(media_data_path, exist_ok=True)
     file_path = os.path.join(media_data_path, filename_with_timestamp)
     wb.save(file_path)

--- a/infra/stage/docker-compose.stage.yaml
+++ b/infra/stage/docker-compose.stage.yaml
@@ -19,7 +19,7 @@ services:
     restart: always
     volumes:
       - static_value:/app/adaptive_hockey_federation/static/
-      - media_value:/app/adaptive_hockey_federation/media/
+      - media_value:/app/adaptive_hockey_federation/media/:/var/html/media/
     env_file:
       - ../../.env
     depends_on:

--- a/infra/stage/docker-compose.stage.yaml
+++ b/infra/stage/docker-compose.stage.yaml
@@ -18,9 +18,8 @@ services:
     container_name: adaptive_hockey_federation
     restart: always
     volumes:
-      - ./media:/config/media/
       - static_value:/app/adaptive_hockey_federation/static/
-      - media_value:/app/adaptive_hockey_federation/media/
+      - ../../media:/app/adaptive_hockey_federation/media/
     env_file:
       - ../../.env
     depends_on:
@@ -42,7 +41,7 @@ services:
       - ../nginx/nginx_stage.conf:/config/nginx/site-confs/default.conf
       - swag_volume_stage:/config
       - static_value:/var/html/static/
-      - media_value:/var/html/media/
+      - ../../media:/var/html/media/
     ports:
       - 443:443
       - 80:${PORT}
@@ -54,6 +53,5 @@ services:
 
 volumes:
   static_value:
-  media_value:
   postgres_data:
   swag_volume_stage:

--- a/infra/stage/docker-compose.stage.yaml
+++ b/infra/stage/docker-compose.stage.yaml
@@ -18,8 +18,9 @@ services:
     container_name: adaptive_hockey_federation
     restart: always
     volumes:
+      - ./media:/config/media/
       - static_value:/app/adaptive_hockey_federation/static/
-      - media_value:/app/adaptive_hockey_federation/media/:/var/html/media/
+      - media_value:/app/adaptive_hockey_federation/media/
     env_file:
       - ../../.env
     depends_on:


### PR DESCRIPTION
# Description

Было необходимо пробросить volumes для media, так, чтобы были доступны с каталога виртуальной машины для просмотра. Так же было необходимо переименовать папки хранения.

- Были внесены изменения в infra/stage/docker-compose.stage.yaml:22
- Были переименованы названия создаваемых папок в: 
   - adaptive_hockey_federation/main/models.py:460
   - adaptive_hockey_federation/unloads/models.py:25

