### PR TITLE
bugfix: pagination.html

### DIFF
--- a/adaptive_hockey_federation/templates/base/pagination.html
+++ b/adaptive_hockey_federation/templates/base/pagination.html
@@ -2,10 +2,10 @@
   <ul class="pagination justify-content-center mb-0 mt-1">
     {% if page_obj.has_previous %}
       <li class="page-item">
-        <a class="page-link pg-list bi bi-chevron-double-left" href="?page=1" aria-label="First"></a>
+        <a class="page-link pg-list bi bi-chevron-double-left" href="?page=1{% if request.GET.search %}&search={{ request.GET.search }}{% endif %}" aria-label="First"></a>
       </li>
       <li class="page-item">
-        <a class="page-link pg-list bi bi bi-chevron-left" href="?page={{ page_obj.previous_page_number }}" aria-label="Previous"></a>
+        <a class="page-link pg-list bi bi bi-chevron-left" href="?page={{ page_obj.previous_page_number }}{% if request.GET.search %}&search={{ request.GET.search }}{% endif %}" aria-label="Previous"></a>
       </li>
     {% endif %}
 
@@ -17,7 +17,7 @@
           </li>
         {% else %}
           <li class="page-item page-num pg-list">
-            <a class="page-link pg-list" href="?page={{ num }}">{{ num }}</a>
+            <a class="page-link pg-list" href="?page={{ num }}{% if request.GET.search %}&search={{ request.GET.search }}{% endif %}">{{ num }}</a>
           </li>
         {% endif %}
       {% endif %}
@@ -25,10 +25,10 @@
 
     {% if page_obj.has_next %}
       <li class="page-item">
-        <a class="page-link pg-list bi bi-chevron-right" href="?page={{ page_obj.next_page_number }}" aria-label="Next"></a>
+        <a class="page-link pg-list bi bi-chevron-right" href="?page={{ page_obj.next_page_number }}{% if request.GET.search %}&search={{ request.GET.search }}{% endif %}" aria-label="Next"></a>
       </li>
       <li class="page-item">
-        <a class="page-link pg-list bi bi-chevron-double-right" href="?page={{ paginator.num_pages }}" aria-label="Last"></a>
+        <a class="page-link pg-list bi bi-chevron-double-right" href="?page={{ paginator.num_pages }}{% if request.GET.search %}&search={{ request.GET.search }}{% endif %}" aria-label="Last"></a>
       </li>
     {% endif %}
   </ul>


### PR DESCRIPTION
# Description

Исправлен баг в пагинации, при работе с поиском/фильтром. Оснавная проблема была, при переходе на следующую страницу избранного списка например игроков, результаты фильтра сбрасывались и показывали просто номинальную страницу с игроками.
Ниже представлены скрины, с примером работы после решения бага.

Выполняем поиск на странице:
![Снимок экрана от 2024-03-31 10-54-28](https://github.com/Studio-Yandex-Practicum/adaptive_hockey_federation/assets/106034945/72fe1078-d899-48cd-9fdf-be6e7f87efab)

Переходим на вторую страницу (представлена работа с багом):
![Снимок экрана от 2024-03-31 10-54-37](https://github.com/Studio-Yandex-Practicum/adaptive_hockey_federation/assets/106034945/2c9b96b1-7139-4b20-8b32-5108d8e2012f)

Переходим на вторую страницу (правильная работа), выборка фильтра сохранилась, можно убедится по url в адресной строке браузера.
![Снимок экрана от 2024-03-31 10-56-00](https://github.com/Studio-Yandex-Practicum/adaptive_hockey_federation/assets/106034945/9ef78635-23c9-4bff-8ec7-d905483290fb)

Так же этот баг исправлен для кнопок пагинации (вперёд-назад, к первой-последней странице).
## Type of change

Пожалуйста, удалите варианты, которые не относятся к ПР-у.

- [ ] Documentation (опечатки, примеры кода или любое обновление документации)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Мануальное тестирование на локальном хосте.

## Checklist:

- [x] Мой код соответствует code-style данного проекта
- [x] Я провел самоанализ собственного кода
- [ ] Я внес соответствующие изменения в документацию

