### PR TITLE
Команда для создания тестовых данных на стейдже.

### DIFF
--- a/adaptive_hockey_federation/core/management/commands/fill-test-stage.py
+++ b/adaptive_hockey_federation/core/management/commands/fill-test-stage.py
@@ -1,0 +1,32 @@
+import subprocess
+
+from django.core.management.base import BaseCommand
+
+base_commands = "python manage.py fill-test-db "
+commands = (
+    "--users",
+    "--diagnosis --amount 8",
+    "--discipline --amount 3",
+    "--team --amount 20",
+    "--staffteam",
+    "--player --amount 300",
+    "--document",
+    "--competition --amount 10",
+)
+
+
+class Command(BaseCommand):
+
+    help = "Наполнение базы данных тестовыми данными."
+
+    def handle(self, *args, **options):
+        for argument in commands:
+
+            result = subprocess.run(
+                base_commands + argument,
+                shell=True,
+                capture_output=True,
+                text=True,
+            )
+            print(self.style.SUCCESS(result.stdout))
+        return self.style.SUCCESS("Создание фикстур завершено!")


### PR DESCRIPTION
# Description

Необходимость обусловлена тем что, команда ```make fill-test-db``` внутри контейнера на VPS не работает, и при каждом обновлении миграций набирать поочерёдно команды для создания фикстур для каждой модели не совсем удобно.
Вместо набора команд:
```
python fill-test-db --users
python fill-test-db --diagnosis --amount 8
python fill-test-db --discipline --amount 3
python fill-test-db --team --amount 20
python fill-test-db --staffteam
python fill-test-db --player --amount 300
python fill-test-db --document
python fill-test-db --competition --amount 10
```
используется:
```
python manage.py fill-test-stage
```

Согласен что решение не самое тривиальное, стоит доработать ```fill-test-db``` для универсальной работы, на локалке и на стейдже.

## Type of change

Пожалуйста, удалите варианты, которые не относятся к ПР-у.

- [ ] Documentation (опечатки, примеры кода или любое обновление документации)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Мануальное тестирование на локальном хосте.

## Checklist:

- [x] Мой код соответствует code-style данного проекта
- [x] Я провел самоанализ собственного кода
- [x] Я внес соответствующие изменения в документацию
