### PR TITLE
bugfix: fix creation/edit player card

### DIFF
--- a/adaptive_hockey_federation/main/forms.py
+++ b/adaptive_hockey_federation/main/forms.py
@@ -16,7 +16,6 @@ from django.shortcuts import get_object_or_404
 from main.models import (
     City,
     Diagnosis,
-    DisciplineLevel,
     DisciplineName,
     Nosology,
     Player,
@@ -143,12 +142,6 @@ class PlayerForm(forms.ModelForm):
             "birthday": FORM_HELP_TEXTS["birthday"],
         }
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.fields["discipline_level"].queryset = (
-            DisciplineLevel.objects.none()
-        )
-
     def save_m2m(self):
         self.instance.team.through.objects.filter(
             team__in=self.cleaned_data["team"]
@@ -190,11 +183,6 @@ class PlayerUpdateForm(PlayerForm):
 
     def __init__(self, *args, **kwargs):
         super(PlayerForm, self).__init__(*args, **kwargs)
-        self.fields["discipline_level"].queryset = (
-            DisciplineLevel.objects.filter(
-                discipline_name_id=self.instance.discipline_name.id
-            )
-        )
         if queryset := self.instance.team.all():
             self.fields["team"] = CustomModelMultipleChoiceField(
                 queryset=queryset,


### PR DESCRIPTION
# Description

Починил форму создания/редактирования игрока, теперь всё создаётся и редактируется. 

При создании нового игрока выпадающий список со статусами будет такой, как он был раньше (когда показываются все числовые статусы), а уже при выборе дисциплины будет отрабатывать аякс-скрипт, и там будут подгружаться только подходящие статусы. Аналогично и для редактирования

## Type of change

Пожалуйста, удалите варианты, которые не относятся к ПР-у.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Опишите, пожалуйста, тесты, которые вы провели для проверки ваших изменений. Предоставьте инструкции, чтобы мы могли воспроизвести их. Также укажите все необходимые детали конфигурации тестов.

- pytest
- pre-commit checks

## Checklist:

- [x] Мой код соответствует code-style данного проекта
- [x] Я провел самоанализ собственного кода
- [x] Я внес соответствующие изменения в документацию - не требуется
