### PR TITLE
fix game_team query

### DIFF
--- a/adaptive_hockey_federation/games/views.py
+++ b/adaptive_hockey_federation/games/views.py
@@ -188,7 +188,10 @@ class EditTeamPlayersNumbersView(
     def get_form_kwargs(self):
         """Передача дополнительных аргументов в форму."""
         kwargs = super().get_form_kwargs()
-        game_team = get_object_or_404(GameTeam, id=self.kwargs["game_team"])
+        game_team = get_object_or_404(
+            GameTeam,
+            gameteam_id=self.kwargs["game_team"],
+        )
         kwargs["game_team"] = game_team
         if self.request.method == "POST":
             kwargs["data"] = self.request.POST
@@ -209,7 +212,7 @@ class EditTeamPlayersNumbersView(
         context = super().get_context_data(**kwargs)
         context["game_team"] = get_object_or_404(
             GameTeam,
-            id=self.kwargs["game_team"],
+            gameteam_id=self.kwargs["game_team"],
         )
         context["page_title"] = "Редактирование номеров игроков команды"
         return context

--- a/adaptive_hockey_federation/templates/main/games/game_detail.html
+++ b/adaptive_hockey_federation/templates/main/games/game_detail.html
@@ -41,7 +41,7 @@
                 {% endfor %}
             </tbody>
         </table>
-        <a href="{% url 'games:edit_team_players_numbers' game_team=teams.0.id %}"
+        <a href="{% url 'games:edit_team_players_numbers' game_team=teams.0.gameteam_id %}"
            class="btn btn-secondary text-white"
            style="background-color: #64C2D1; border: 1px solid #fff; margin-right: 10px; margin-top: 5px;">
            Редактировать номера игроков
@@ -74,7 +74,7 @@
                 {% endfor %}
             </tbody>
         </table>
-        <a href="{% url 'games:edit_team_players_numbers' game_team=teams.1.id %}"
+        <a href="{% url 'games:edit_team_players_numbers' game_team=teams.1.gameteam_id %}"
            class="btn btn-secondary text-white"
            style="background-color: #64C2D1; border: 1px solid #fff; margin-right: 10px; margin-top: 5px;">
            Редактировать номера игроков


### PR DESCRIPTION
# Description
Проблема была в том, что фильтровались объекты по id (ссылка на Team), который не уникальный. get_object_or_404() падал из-за того что ждет получить 1 объект. Поправил в шаблоне и представлении фильтрацию по pk (gameteam_id) в GameTeam.

## Type of change

Пожалуйста, удалите варианты, которые не относятся к ПР-у.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Checklist:

- [x] Мой код соответствует code-style данного проекта
- [x] Я провел самоанализ собственного кода
- [ ] Я внес соответствующие изменения в документацию
