### PR TITLE
Refactor requests to DS API, add YandexDist token to settings and .env.example (#506)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,7 +18,7 @@ POSTGRES_USER='django'
 POSTGRES_DB='django'
 DB_HOST='localhost'
 DB_PORT='5432'
-
+# Email settings
 EMAIL_BACKEND='django.core.mail.backends.smtp.EmailBackend'
 EMAIL_HOST='smtp.yandex.ru'
 EMAIL_PORT=587
@@ -36,3 +36,5 @@ SETTINGS_LEVEL=dev
 CELERY_BROKER_HOST=localhost
 CELERY_BROKER_PORT=6379
 CELERY_VISIBILITY_TIMEOUT=360
+# Yandex Disk settings
+YANDEX_DISK_OAUTH_TOKEN=ya_oauth_token

--- a/adaptive_hockey_federation/core/config/base_settings.py
+++ b/adaptive_hockey_federation/core/config/base_settings.py
@@ -163,7 +163,6 @@ API_DOCS_KEY = env("API_DOCS_KEY", default="8f2d9e1b2c4e6f")
 PROCESSING_SERVICE_BASE_URL = env('PROCESSING_SERVICE_BASE_URL', default='http://127.0.0.1:8010/')
 
 # Celery config
-
 CELERY_BROKER_URL = f'redis://{env("CELERY_BROKER_HOST", default="localhost")}:{env("CELERY_BROKER_PORT", default="6379")}/{env("REDIS_BROKER_DATABASE_LEVEL", default=0)}' # noqa E501
 CELERY_BROKER_TRANSPORT_OPTIONS = {
     'visibility_timeout': env('CELERY_VISIBILITY_TIMEOUT', default=360)
@@ -172,3 +171,5 @@ CELERY_RESULT_BACKEND = CELERY_BROKER_URL
 CELERY_ACCEPT_CONTENT = ['application/json']
 CELERY_TASK_SERIALIZER = 'json'
 CELERY_RESULT_SERIALIZER = 'json'
+
+YANDEX_DISK_OAUTH_TOKEN = env("YANDEX_DISK_OAUTH_TOKEN", default="ya_oauth_token")

--- a/adaptive_hockey_federation/games/signals.py
+++ b/adaptive_hockey_federation/games/signals.py
@@ -55,7 +55,7 @@ def create_game_teams(sender, instance, created, **kwargs):
             request_data = {"json": data_from_json}
 
         get_player_video_frames.apply_async(
-            args=["/process", request_data],
+            kwargs={"data": request_data},
             queue="process_queue",
             priority=255,
         )

--- a/adaptive_hockey_federation/service/a_hockey_requests.py
+++ b/adaptive_hockey_federation/service/a_hockey_requests.py
@@ -2,31 +2,44 @@ from typing import Any
 from urllib.parse import urljoin
 
 import requests
+from requests.exceptions import RequestException
 from django.conf import settings
 
 
-def send_request_to_video_processing_service(
-    path: str,
-    request_data: dict[str, Any],
-    base_url: str = settings.PROCESSING_SERVICE_BASE_URL,
-    http_method: str = "post",
-    **kwargs: dict[Any, Any],
-) -> requests.Response:
+def check_api_health_status() -> None:
     """
-    Отправка запросов к эндпоинтам сервиса по обработке видео с играми.
+    Отправка запроса на эндпоинт /health для проверки состояния сервиса.
 
-    Обрабатывает все поддерживаемые http методы библиотекой requests.
-    Формируется конечный адрес base_url + path, куда будет отправлен запрос,
-    В аргументе request_data передается словарь,
-    содержащий имя аргмуента и значение требуемые
-    сигатурой соответствующего http метода.
+    :raises RequestException: Если возникла ошибка.
     """
-    endpoint = urljoin(base_url, path)
-    if hasattr(requests, http_method.lower()):
-        response = getattr(requests, http_method)(
-            endpoint,
-            **request_data,
-            **kwargs,
+    try:
+        response = requests.get(
+            urljoin(settings.PROCESSING_SERVICE_BASE_URL, "/health"),
         )
-        return response
-    raise AttributeError(f"Http метод: {http_method} не обслуживается")
+        response.raise_for_status()
+    except RequestException as error:
+        raise RequestException(
+            f"Сервис по обработке видео недоступен: {error}",
+        ) from error
+
+
+def send_request_to_process_video(
+    data: dict[str, Any],
+) -> dict[str, Any]:
+    """
+    Отправка запроса к эндпоинту /process для обработки видео.
+
+    :param data: Словарь с данными для обработки видео.
+    :returns: Результат обработки видео.
+    :raises RequestException: Если возникла ошибка при обработке видео.
+    """
+    try:
+        response = requests.post(
+            urljoin(settings.PROCESSING_SERVICE_BASE_URL, "/process"),
+            json=data,
+        )
+        return response.json()
+    except RequestException as error:
+        raise RequestException(
+            f"Возникла ошибка при попытке обработать видео: {error}",
+        ) from error

--- a/adaptive_hockey_federation/video_api/serializers.py
+++ b/adaptive_hockey_federation/video_api/serializers.py
@@ -1,6 +1,8 @@
+from django.conf import settings
+from rest_framework import serializers
+
 from games.models import Game, GamePlayer
 from main.models import Player
-from rest_framework import serializers
 
 
 class GameFeatureSerializer(serializers.ModelSerializer):
@@ -45,8 +47,7 @@ class GameFeatureSerializer(serializers.ModelSerializer):
 
     def get_token(self, obj):
         """Метод токена."""
-        # TODO: заглушка для отправки токена
-        return "y0_AgAAAAA8cbR4AAtjkQAAAAD9CA6QAAA7HIEFePpA7qKzGdujIAwVc_JH9w"
+        return settings.YANDEX_DISK_OAUTH_TOKEN
 
 
 class TrackingSerializer(serializers.Serializer):

--- a/adaptive_hockey_federation/video_api/tasks.py
+++ b/adaptive_hockey_federation/video_api/tasks.py
@@ -1,23 +1,24 @@
 import time
 import json
 from pathlib import Path
-from celery_singleton import Singleton
+
+from django.db import transaction
+from celery import current_app
 from celery.signals import task_success, worker_process_init
+from celery_singleton import Singleton
+
 from core.celery import app
-from service.a_hockey_requests import send_request_to_video_processing_service
+from service.a_hockey_requests import send_request_to_process_video
 from service.video_processing import slicing_video_with_player_frames
 from games.models import GameDataPlayer
 from .serializers import GameDataPlayerSerializer
-from celery import current_app
-from django.db import transaction
 
 
 @app.task(base=Singleton)
 def get_player_video_frames(*args, **kwargs):
     """Таск для запуска обработки видео."""
     print("Добавлен новый объект игры, запускаем воркер")
-    path, data = args[0], args[1]
-    response = send_request_to_video_processing_service(path, data)
+    response = send_request_to_process_video(kwargs.get("data"))
     return response.content
 
 


### PR DESCRIPTION
# Description

Issue: [#506](https://github.com/Studio-Yandex-Practicum/adaptive_hockey_federation/issues/506)
1. Сделал функцию для проверки состояния API DS'ов путем отправки запроса на эндпойнт /health
2. Переделал функуцию для отправки данных для обработки видео на API DS'ов на эндпойнт /process
3. Скорректировал API представление для отправки данных на API API DS'ов. 
4. Добавил токен Яндекс Диска в настройки и в файл env.example
## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Для проверки коректного отправления запросов локально поднимал урезанный дубликат апи DS'ов.

```
from pprint import pprint

from fastapi import FastAPI
from pydantic import BaseModel  

app = FastAPI() 

class GameFeatures(BaseModel):
    game_id: int | None = None
    game_link: str | None = None
    token: str | None = None
    player_ids: list | None = None
    player_numbers: list | None = None
    team_ids: list | None = None 

@app.get('/health')
def health():
    return {"status": "OK", "version": 1.0}

@app.post('/process')
async def process(
    data: GameFeatures,
):
    pprint(data)
    return data
```

## Checklist:

- [x] Мой код соответствует code-style данного проекта
- [x] Я провел самоанализ собственного кода
