### PR TITLE
Add celery tasks to download videos from Y.disk, to slice video with player moments. (#529)

### DIFF
--- a/adaptive_hockey_federation/core/celery.py
+++ b/adaptive_hockey_federation/core/celery.py
@@ -26,4 +26,5 @@ app.conf.broker_transport_options = {
 app.conf.task_queues = (
     Queue("process_queue"),
     Queue("slice_player_video_queue"),
+    Queue("download_game_video_queue"),
 )

--- a/adaptive_hockey_federation/core/constants.py
+++ b/adaptive_hockey_federation/core/constants.py
@@ -180,5 +180,16 @@ SEARCH_ALIAS = {
 class Directory:
     """Директории."""
 
+    GAMES = "games"
     PLAYER_VIDEO_DIR = "player_video"
     UNLOAD_DIR = "unloads_data"
+
+
+class YadiskDirectory(StrEnum):
+    """Директории на Яндекс.Диске."""
+
+    GAMES = "games"
+    PLAYER_GAMES = "player_games"
+
+
+PLAYER_GAME_NAME = "{surname}_{name[0]}_{patronymic[0]}_{game_name}.mp4"

--- a/adaptive_hockey_federation/core/ydisk_utils/utils.py
+++ b/adaptive_hockey_federation/core/ydisk_utils/utils.py
@@ -1,13 +1,20 @@
+import os
 import logging
 import sys
+from functools import wraps
 
 import yadisk
+from yadisk import Client
 from django.conf import settings
 from yadisk.exceptions import (
     ForbiddenError,
     PathNotFoundError,
     ResourceIsLockedError,
 )
+
+from core.celery import app
+from core.constants import YadiskDirectory
+
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.WARNING)
@@ -23,31 +30,77 @@ console_handler.setFormatter(formatter)
 logger.addHandler(console_handler)
 
 
-def download_file(video_link: str, media_data_path: str) -> str | None:
-    """Скачать файл с Yandex Disk."""
-    error_message: str | None = None
-    # TODO Это нужно будет сделать в виде воркера. Сейчас у нас непонятно,
-    # скачался файл или нет.
-    client = yadisk.Client(token=settings.YANDEX_DISK_OAUTH_TOKEN)
+def yadisk_client(func):
+    """
+    Декоратор для работы с клиентом Yandex Disk.
 
-    with client:
-        if not client.check_token():
-            error_message = "Токен Yandex Disk недействителен."
-            logger.exception(error_message)
-            return error_message
+    Декорируемая функция должна принимать первым аргументом экземпляр
+    `yadisk.Client`.
 
+    Пример использования:
+        @yadisk_client
+        def function(client, *args, **kwargs):
+            pass
+    """
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
         try:
-            client.download_by_link(video_link, media_data_path)
+            with yadisk.Client(
+                token=settings.YANDEX_DISK_OAUTH_TOKEN,
+            ) as client:
+                return func(client, *args, **kwargs)
         except PathNotFoundError:
-            error_message = f"Файл {video_link} не найден на Yandex Disk."
+            error_message = "Файл не найден на Yandex Disk."
             logger.exception(error_message)
+            raise PathNotFoundError(msg=error_message)
         except ForbiddenError:
             error_message = "Не хватает прав, чтобы выполнить запрос."
             logger.exception(error_message)
+            raise ForbiddenError(msg=error_message)
         except ResourceIsLockedError:
-            error_message = f"Файл {video_link} заблокирован другой операцией."
+            error_message = "Файл заблокирован другой операцией."
             logger.exception(error_message)
-        except Exception as error:
-            logger.exception("Error")
-            return str(error)
-        return error_message
+            raise ResourceIsLockedError(msg=error_message)
+
+    return wrapper
+
+
+@yadisk_client
+def check_file_exists_on_disk(client: Client, file_path: str) -> bool:
+    """Проверить существование файла на Yandex Disk."""
+    return client.exists(file_path)
+
+
+@yadisk_client
+def download_file_by_link(
+    client: Client,
+    video_link: str,
+    media_data_path: str,
+) -> None:
+    """Скачать файл с Yandex Disk по ссылке."""
+    client.download_public(video_link, media_data_path)
+
+
+def check_player_game_exists_on_disk(player_game_file_name: str) -> bool:
+    """Проверить существование файла с игроком на Yandex Disk."""
+    player_game_path_on_disk = os.path.join(
+        YadiskDirectory.PLAYER_GAMES,
+        player_game_file_name,
+    )
+    return check_file_exists_on_disk(player_game_path_on_disk)
+
+
+@app.task
+def download_file_by_link_task(
+    video_link: str,
+    media_data_path: str,
+):
+    """Задача для скачивания файла с Yandex Disk."""
+    if os.path.exists(media_data_path):
+        logger.info(f"Файл {media_data_path} уже скачан на диске.")
+        return
+    download_file_by_link(
+        video_link=video_link,
+        media_data_path=media_data_path,
+    )

--- a/adaptive_hockey_federation/main/controllers/player_views.py
+++ b/adaptive_hockey_federation/main/controllers/player_views.py
@@ -7,17 +7,22 @@ from django.contrib.auth.mixins import (
     LoginRequiredMixin,
     PermissionRequiredMixin,
 )
+from django.contrib.auth.decorators import login_required
 from django.http import Http404
 from django.shortcuts import get_object_or_404, render, redirect
 from django.urls import reverse, reverse_lazy
 from django.views.generic.detail import DetailView
 from django.views.generic.edit import CreateView, DeleteView, UpdateView
 from django.views.generic.list import ListView
+from celery import chain
 
-from core.constants import Directory, FileConstants
+from core.constants import Directory, FileConstants, PLAYER_GAME_NAME
 from core.utils import is_uploaded_file_valid
-from core.ydisk_utils.utils import download_file
-from games.models import Game, GamePlayer
+from core.ydisk_utils.utils import (
+    download_file_by_link_task,
+    check_player_game_exists_on_disk,
+)
+from games.models import Game, GamePlayer, GameDataPlayer
 from main.controllers.mixins import DiagnosisListMixin
 from main.controllers.utils import errormessage
 from main.forms import PlayerForm, PlayerUpdateForm
@@ -409,50 +414,125 @@ class PlayerGamesVideo(
         return context
 
 
+@login_required
 def unload_player_game_video(request, **kwargs):
-    # мок версия запроса видео с моментами игрока от менеджера
-    # TODO Должна быть проверка видео на я.диске если его нет
-    # проверять есть ли фреймы с игроком в бд если нет
-    # запускать полный цикл тасков
+    """
+    Обрабатывает запрос на получение видео с моментами игрока из игры.
 
-    # TODO Заменить ссылку с игрой на ссылку с игроком.
-    game = Game.objects.get(pk=kwargs["game_id"])
-    if not game.video_link:
-        create_player_video.apply_async(
-            args=["Обработка с высоким приоритетом"],
-            queue="slice_player_video_queue",
-            priority=0,
+    Функция выполняет следующие шаги:
+    1. Получает игрока и игру по идентификаторам.
+    2. Формирует путь для сохранения видео игры и обработки моментов с игроком.
+    3. Проверяет наличие уже существующего видео с моментами игрока на я.диске:
+       - Если видео уже существует, возвращает ссылку на его скачивание.
+       - Если видео отсутствует, проверяет наличие фреймов игрока в бд:
+         - Если фреймы есть, запускает процесс скачивания видео игры, нарезки
+           моментов с игроком, загрузки видео на я.диск и отправки ссылки
+           пользователю.
+         - Если фреймов нет, запускает полный процесс обработки, включая
+           получение данных с сервера, скачивание видео игры, нарезку моментов,
+           загрузку видео и отправку ссылки пользователю.
+    4. Отправляет сообщение пользователю с информацией о статусе обработки
+        видео и ссылки на его скачивание.
+    5. Перенаправляет пользователя на страницу с видео игрока.
+    """
+    player_id = kwargs["player_id"]
+    player = get_object_or_404(Player, pk=player_id)
+    game = get_object_or_404(Game, pk=kwargs["game_id"])
+
+    player_game_file_name = PLAYER_GAME_NAME.format(
+        surname=player.surname,
+        name=player.name,
+        patronymic=player.patronymic,
+        game_name=game.name,
+    )
+
+    # Директория для скаченных видео с играми.
+    games_dir = os.path.join(
+        settings.MEDIA_ROOT,
+        Directory.GAMES,
+    )
+    os.makedirs(games_dir, exist_ok=True)
+    game_path = os.path.join(
+        games_dir,
+        f"{game.name}.mp4",
+    )
+
+    # Директория для обработанных моментов с игроком.
+    player_games_dir = os.path.join(
+        settings.MEDIA_ROOT,
+        Directory.PLAYER_VIDEO_DIR,
+    )
+    os.makedirs(player_games_dir, exist_ok=True)
+    player_game_frames_path = os.path.join(
+        player_games_dir,
+        player_game_file_name,
+    )
+
+    if check_player_game_exists_on_disk(player_game_file_name):
+        # Проверяем есть ли видео с моментами игрока на я.диске.
+
+        process_chain = chain(
+            # TODO реализовать таску по отправке ссылки пользователю
         )
 
-        messages.add_message(
-            request,
-            messages.INFO,
-            f"Видео по игре «{game.name}» находится в обработке. "
-            "Пожалуйста дождитесь скачивания.",
+        message_text = "Ссылка для скачивания видео отправлена на почту."
+    elif GameDataPlayer.objects.filter(player=player, game=game).exists():
+        # Проверяем если ли фреймы с игроком в бд. Если есть, то:
+
+        process_chain = chain(
+            download_file_by_link_task.si(game.video_link, game_path).set(
+                queue="download_game_video_queue",
+            ),
+            create_player_video.si(
+                game_path,
+                player_game_frames_path,
+                player.id,
+                game.id,
+            ).set(queue="slice_player_video_queue"),
+            # TODO реализовать таску по загрузке видео с игроком на Я.диск
+            # TODO реализовать таску по отправке ссылки пользователю
+        )
+
+        message_text = (
+            "Видео находится в обработке. "
+            "Ссылка для скачивания видео будет отправлена на почту."
         )
     else:
-        player = str(Player.objects.get(pk=kwargs["player_id"]))
-        media_data_path = os.path.join(
-            settings.MEDIA_ROOT,
-            Directory.PLAYER_VIDEO_DIR,
-            str(game),
-        )
-        os.makedirs(media_data_path, exist_ok=True)
-        video_file = os.path.join(media_data_path, f"{player}.mp4")
+        # Если нет ни видео, не фреймов, то запускаем полный цикл тасков.
 
-        error_message = download_file(game.video_link, video_file)
-
-        messages.add_message(
-            request,
-            messages.ERROR if error_message else messages.INFO,
-            error_message or f"Видео сохранено в файле {video_file}.",
+        process_chain = chain(
+            # get_player_video_frames.si().set(queue="process_queue"),
+            download_file_by_link_task.si(game.video_link, game_path).set(
+                queue="download_game_video_queue",
+            ),
+            create_player_video.si(
+                game_path,
+                player_game_frames_path,
+                player.id,
+                game.id,
+            ).set(queue="slice_player_video_queue"),
+            # TODO реализовать таску по загрузке видео с игроком на Я.диск
+            # TODO реализовать таску по отправке ссылки пользователю
         )
+
+        message_text = (
+            "Видео находится в обработке. "
+            "Ссылка для скачивания видео будет отправлена на почту."
+        )
+
+    process_chain.apply_async()
+
+    messages.add_message(
+        request,
+        messages.INFO,
+        message_text,
+    )
 
     # TODO видео будет автоматически загрузаться пользователю по готовности.
     # Возможно нужно ресерчить тему WebSockets, SSE
     return redirect(
         "main:player_id_games_video",
-        pk=kwargs["player_id"],
+        pk=player_id,
     )
 
 

--- a/adaptive_hockey_federation/service/video_processing.py
+++ b/adaptive_hockey_federation/service/video_processing.py
@@ -18,7 +18,7 @@ def slicing_video_with_player_frames(input_file, output_file, frames, fps=25):
     cap = cv2.VideoCapture(input_file)
     width = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
     height = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
-    fourcc = cv2.VideoWriter_fourcc("X", "V", "I", "D")
+    fourcc = cv2.VideoWriter_fourcc(*"mp4v")
     output = cv2.VideoWriter(output_file, fourcc, fps, (width, height))
 
     for fr in range(len(frames)):  # frames - список фреймов с игроком

--- a/adaptive_hockey_federation/video_api/tasks.py
+++ b/adaptive_hockey_federation/video_api/tasks.py
@@ -1,6 +1,5 @@
-import time
+import os
 import json
-from pathlib import Path
 
 from django.db import transaction
 from celery import current_app
@@ -23,17 +22,28 @@ def get_player_video_frames(*args, **kwargs):
 
 
 @app.task()
-def create_player_video(*args, **kwargs):
-    # TODO моковая реализация, должно передаваться данные
-    # необходимые для нарезки видео с игроком
-    time.sleep(10)
-    args = args[0]
-    game_link = "https://disk.yandex.ru/i/JLh__1IbAfmK-Q"
-    output_file = (
-        Path(__file__).resolve().parent.parent / "service/test_video/test.mp4"
-    )
+def create_player_video(
+    input_file,
+    output_file,
+    player_id,
+    game_id,
+    *args,
+    **kwargs,
+):
+    """Таск для нарезки видео с моментами игрока."""
+    # Мок реализация фреймов для нарезки видео с моментами игрока.
+    # Пока подставляются тестовые фреймы.
+    # TODO удалить мок реализацию, как в бд появятся фреймы по игрокам.
+
+    if os.path.exists(output_file):
+        return
+
     frames = [i for i in range(15000, 15430, 5)]
-    slicing_video_with_player_frames(game_link, output_file, frames)
+    # frames = GameDataPlayer.objects.filter(
+    #     player_id=player_id, game_id=game_id
+    # ).first().data
+
+    slicing_video_with_player_frames(input_file, output_file, frames)
     return f"Видео обработано. {args}"
 
 


### PR DESCRIPTION
issue: [#529](https://github.com/Studio-Yandex-Practicum/adaptive_hockey_federation/issues/529)
# Description

1. Сделал рефактор кода для работы с Яндекс Диском.
2. Сделал таску celery для скачивания видео по ссылке на яндекс диск.
3. Изменил вью функцию для обработки видео. Она теперь обрабатывает 3 ситуации.
	1. Когда видео с игроком уже нарезано и сохранено на я.диске.
	2. Когда такое видео отсутствует, но в бд есть фреймы для нарезки видео.
	3. Когда нет ни видео, ни фреймов. В таком случае должен запускаться полный цикл тасков.

Замерил время нарезки видео по фреймам. Для проверки, подставлял данные, которые ты отправлял в пачке. Задаче celery понадобилось примерно 18-19 минут, чтобы нарезать одно видео.

Также есть предложение по изменению таски для запроса к серверу ДСов. Предлагаю предавать в нее ид игры, чтобы она уже получала эти значения, осуществляла сериализацию и отправляла запрос серверу ДСов.
## Type of change
- [x] New feature (non-breaking change which adds functionality)
# How Has This Been Tested?
Руtest, ручное тестирование
## Checklist:

- [x] Мой код соответствует code-style данного проекта
- [x] Я провел самоанализ собственного кода

