### PR TITLE
Add commands export-db and import-db.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,8 @@ help:
 	@echo "	run             - $(SHELL_GREEN)Команда для локального запуска проекта.$(SHELL_NC)."
 	@echo "	fill-db         - $(SHELL_GREEN)Команда для заполнения базы данных реальными данными из json фикстур.$(SHELL_NC)."
 	@echo "	fill-test-db    - $(SHELL_GREEN)Команда для заполнения базы данных тестовыми данными при помощи фабрик генерации данных.$(SHELL_NC)."
+	@echo "	export-db       - $(SHELL_GREEN)Команда для экспорта данных из БД в JSON файл.$(SHELL_NC)."
+	@echo "	import-db       - $(SHELL_GREEN)Команда для импорта данных из JSON файла в БД.$(SHELL_NC)."
 	@echo "	pytest          - $(SHELL_GREEN)Команда для прогона юнит тестов pytest.$(SHELL_NC)."
 	@echo "	shell           - $(SHELL_GREEN)Команда для запуска Django-shell_plus.$(SHELL_NC)."
 	@echo "	ds-mock         - $(SHELL_GREEN)Команда для запуска имитации DS сервера (порт 8010).$(SHELL_NC)."
@@ -119,6 +121,16 @@ fill-test-db:
 	cd $(PROJECT_DIR) && $(DJANGO_RUN) fill-test-db --unload
 	cd $(PROJECT_DIR) && $(DJANGO_RUN) fill-test-db --game --amount 10
 	cd $(PROJECT_DIR) && $(DJANGO_RUN) fill-test-db --json-player-data --amount 10
+
+
+# Экспорт данных из бд
+export-db:
+	cd $(DJANGO_DIR) && $(DJANGO_RUN) export-db
+
+
+# Импорт данных в бд
+import-db:
+	cd $(DJANGO_DIR) && $(DJANGO_RUN) import-db
 
 
 # Прогон тестов с помощью pytest.

--- a/adaptive_hockey_federation/core/config/dev_settings.py
+++ b/adaptive_hockey_federation/core/config/dev_settings.py
@@ -29,12 +29,15 @@ DATABASES = {
 }
 
 DJANGO_SUPERUSER_USERNAME = env("DJANGO_SUPERUSER_USERNAME", default="admin")
-DJANGO_SUPERUSER_EMAIL = env("DJANGO_SUPERUSER_EMAIL", default="admin@admin.ru")
+DJANGO_SUPERUSER_EMAIL = env(
+    "DJANGO_SUPERUSER_EMAIL", default="admin@admin.ru"
+)
 DJANGO_SUPERUSER_PASSWORD = env("DJANGO_SUPERUSER_PASSWORD", default="admin")
 
 FIXSTURES_DIR = BASE_DIR / "core" / "fixtures"
 JSON_PARSER_FILE = "data.json"
 FIXSTURES_FILE = FIXSTURES_DIR / JSON_PARSER_FILE
+DB_DUMP_FILE = FIXSTURES_DIR / "db_dump.json"
 RESOURSES_ROOT = BASE_DIR / "resourses"
 
 # Важен порядок ключей для вставки/удаления

--- a/adaptive_hockey_federation/core/management/commands/export-db.py
+++ b/adaptive_hockey_federation/core/management/commands/export-db.py
@@ -1,0 +1,32 @@
+from django.core.management import call_command
+from django.core.management.base import BaseCommand
+
+from adaptive_hockey_federation.core.config.dev_settings import DB_DUMP_FILE
+
+
+class Command(BaseCommand):
+    """Класс экспорта данных из БД."""
+
+    help = "Экспорт данных из базы данных в JSON-файл"
+
+    def handle(self, *args, **options):
+        """Экспортирует данные из БД."""
+        try:
+            call_command(
+                "dumpdata",
+                exclude=["contenttypes", "auth.permission"],
+                natural_foreign=True,
+                natural_primary=True,
+                indent=2,
+                output=DB_DUMP_FILE,
+            )
+
+            return self.stdout.write(
+                self.style.SUCCESS(
+                    f"База данных экспортирована в {DB_DUMP_FILE}",
+                ),
+            )
+        except Exception as e:
+            return self.stdout.write(
+                self.style.ERROR(f"Ошибка при экспорте данных: {str(e)}"),
+            )

--- a/adaptive_hockey_federation/core/management/commands/import-db.py
+++ b/adaptive_hockey_federation/core/management/commands/import-db.py
@@ -1,0 +1,54 @@
+import json
+import os
+
+from django.apps import apps
+from django.core.management import call_command
+from django.core.management.base import BaseCommand
+from django.db import connection
+
+from adaptive_hockey_federation.core.config.dev_settings import DB_DUMP_FILE
+
+
+class Command(BaseCommand):
+    """Класс импорта данных в БД."""
+
+    help = "Импорт данных из JSON-файла в базу данных"
+
+    def handle(self, *args, **options):
+        """Импортирует данные в БД."""
+        if not os.path.exists(DB_DUMP_FILE):
+            return self.stdout.write(
+                self.style.ERROR(f"Файл {DB_DUMP_FILE} не найден"),
+            )
+
+        with open(DB_DUMP_FILE, "r") as f:
+            data = json.load(f)
+        models_to_clear = set(item["model"] for item in data)
+
+        # Очистка таблиц, в которые импортируются данные,
+        # для исключения ошибки unique constraint
+        with connection.cursor() as cursor:
+            for model_name in models_to_clear:
+                try:
+                    app_label, model = model_name.split(".")
+                    model_class = apps.get_model(app_label, model)
+                    table_name = model_class._meta.db_table
+                    cursor.execute(f"TRUNCATE TABLE {table_name} CASCADE")
+                except Exception as e:
+                    return self.stdout.write(
+                        self.style.WARNING(
+                            f"Не удалось очистить таблицу для модели {model_name}: {str(e)}",  # noqa: E501
+                        ),
+                    )
+
+        try:
+            call_command("loaddata", DB_DUMP_FILE)
+            return self.stdout.write(
+                self.style.SUCCESS(
+                    f"Данные из {DB_DUMP_FILE} импортированы в базу данных",
+                ),
+            )
+        except Exception as e:
+            return self.stdout.write(
+                self.style.ERROR(f"Ошибка при импорте данных: {str(e)}"),
+            )


### PR DESCRIPTION
# Description

Добавлены команды export-db и import-db для экспорта и импорта данных базы данных. Эти команды позволяют сохранить текущее состояние БД в JSON-файл и восстановить его при необходимости. Так же для них созданы короткие make команды.

## Type of change

Пожалуйста, удалите варианты, которые не относятся к ПР-у.

- [ ] Documentation (опечатки, примеры кода или любое обновление документации)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Тестирование проводилось вручную:
1. Заполнение БД с помощью команды make fill-db
2. Экспорт данных командой make export-db
3. Очистка БД
4. Импорт данных командой make import-db
5. Проверка соответствия данных до экспорта и после импорта

## Checklist:

- [X] Мой код соответствует code-style данного проекта
- [X] Я провел самоанализ собственного кода
- [X] Я внес соответствующие изменения в документацию
